### PR TITLE
Main fixsnakemake

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Replace the following paths `config.yaml`:
 
 Then you can run preprocessing pipeline by
 ```
-snakemake --cores <number threads> --configfile config.yaml --snakefile calicost.smk all
+snakemake --cores <number threads> --configfile config.yaml --snakefile calicost.smk --keep-incomplete all
 ```
 
 ### Inferring tumor purity per spot (optional)
@@ -125,7 +125,7 @@ To avoid falling into local maxima in CalicoST's optimization objective, we reco
 Then run CalicoST by
 ```
 cd <directory of downloaded example data>
-snakemake --cores 5 --configfile example_config.yaml --snakefile <calicost_dir>/calicost.smk --keep-incomplete all
+snakemake --cores 5 --configfile example_config.yaml --snakefile <calicost_dir>/calicost.smk all
 ```
 
 CalicoST takes about 69 minutes to finish on this example using 5 cores on an HPC. -->

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ To avoid falling into local maxima in CalicoST's optimization objective, we reco
 Then run CalicoST by
 ```
 cd <directory of downloaded example data>
-snakemake --cores 5 --configfile example_config.yaml --snakefile <calicost_dir>/calicost.smk all
+snakemake --cores 5 --configfile example_config.yaml --snakefile <calicost_dir>/calicost.smk --keep-incomplete all
 ```
 
 CalicoST takes about 69 minutes to finish on this example using 5 cores on an HPC. -->

--- a/src/calicost/arg_parse.py
+++ b/src/calicost/arg_parse.py
@@ -26,6 +26,7 @@ def load_default_config():
         "supervision_clone_file" : None,
         "filtergenelist_file" : None,
         "filterregion_file" : None,
+        "initial_min_umi" : 15,
         "secondary_min_umi" : 300,
         "min_snpumi_perspot" : 50,
         'min_percent_expressed_spots' : 0.005,
@@ -86,6 +87,7 @@ def load_default_config():
         "supervision_clone_file" : "str",
         "filtergenelist_file" : "str",
         "filterregion_file" : "str",
+        "initial_min_umi" : "int",
         "secondary_min_umi" : "int",
         "min_snpumi_perspot" : "int",
         'min_percent_expressed_spots' : "float",
@@ -130,7 +132,7 @@ def load_default_config():
 
     category_names = ["", "# supporting files and preprocessing arguments", "# phase switch probability", "# HMRF configurations", "# HMM configurations", "# integer copy number"]
     category_elements = [["input_filelist", "spaceranger_dir", "snp_dir", "output_dir"], \
-                         ["geneticmap_file", "hgtable_file", "normalidx_file", "tumorprop_file", "alignment_files", "supervision_clone_file", "filtergenelist_file", "filterregion_file", "secondary_min_umi", "min_snpumi_perspot", "min_percent_expressed_spots", "bafonly"], \
+                         ["geneticmap_file", "hgtable_file", "normalidx_file", "tumorprop_file", "alignment_files", "supervision_clone_file", "filtergenelist_file", "filterregion_file", "initial_min_umi", "secondary_min_umi", "min_snpumi_perspot", "min_percent_expressed_spots", "bafonly"], \
                          ["nu", "logphase_shift", "npart_phasing"], \
                          ["n_clones", "n_clones_rdr", "min_spots_per_clone", "min_avgumi_per_clone", "maxspots_pooling", "tumorprop_threshold",  "max_iter_outer", "nodepotential", "initialization_method", "num_hmrf_initialization_start",  "num_hmrf_initialization_end", "spatial_weight", "construct_adjacency_method", "construct_adjacency_w"], \
                          ["n_states", "params", "t", "t_phaseing", "fix_NB_dispersion", "shared_NB_dispersion", "fix_BB_dispersion", "shared_BB_dispersion", "max_iter", "tol", "gmm_random_state", "np_threshold", "np_eventminlen"], \

--- a/src/calicost/arg_parse.py
+++ b/src/calicost/arg_parse.py
@@ -26,11 +26,17 @@ def load_default_config():
         "supervision_clone_file" : None,
         "filtergenelist_file" : None,
         "filterregion_file" : None,
+        "htblock_min_snps" : 1,
         "initial_min_umi" : 15,
         "secondary_min_umi" : 300,
         "min_snpumi_perspot" : 50,
         'min_percent_expressed_spots' : 0.005,
         "bafonly" : False,
+        # prephasing
+        "PREPHASING_select_tumor" : False,
+        "PREPHASING_spot_cluster_file" : None,
+        "PREPHASING_num_bins" : 3000,
+        "PREPHASING_min_tumor_spots" : 100,
         # phase switch probability
         "nu" : 1.0,
         "logphase_shift" : -2.0,
@@ -87,11 +93,17 @@ def load_default_config():
         "supervision_clone_file" : "str",
         "filtergenelist_file" : "str",
         "filterregion_file" : "str",
+        "htblock_min_snps" : "int",
         "initial_min_umi" : "int",
         "secondary_min_umi" : "int",
         "min_snpumi_perspot" : "int",
         'min_percent_expressed_spots' : "float",
         "bafonly" : "bool",
+        # prephasing
+        "PREPHASING_select_tumor" : "bool",
+        "PREPHASING_spot_cluster_file" : "str",
+        "PREPHASING_num_bins" : "int",
+        "PREPHASING_min_tumor_spots" : "int",
         # phase switch probability
         "nu" : "float",
         "logphase_shift" : "float",
@@ -132,7 +144,8 @@ def load_default_config():
 
     category_names = ["", "# supporting files and preprocessing arguments", "# phase switch probability", "# HMRF configurations", "# HMM configurations", "# integer copy number"]
     category_elements = [["input_filelist", "spaceranger_dir", "snp_dir", "output_dir"], \
-                         ["geneticmap_file", "hgtable_file", "normalidx_file", "tumorprop_file", "alignment_files", "supervision_clone_file", "filtergenelist_file", "filterregion_file", "initial_min_umi", "secondary_min_umi", "min_snpumi_perspot", "min_percent_expressed_spots", "bafonly"], \
+                         ["geneticmap_file", "hgtable_file", "normalidx_file", "tumorprop_file", "alignment_files", "supervision_clone_file", "filtergenelist_file", "filterregion_file", "htblock_min_snps", "initial_min_umi", "secondary_min_umi", "min_snpumi_perspot", "min_percent_expressed_spots", "bafonly"], \
+                         ["PREPHASING_select_tumor", "PREPHASING_spot_cluster_file", "PREPHASING_num_bins", "PREPHASING_min_tumor_spots"], \
                          ["nu", "logphase_shift", "npart_phasing"], \
                          ["n_clones", "n_clones_rdr", "min_spots_per_clone", "min_avgumi_per_clone", "maxspots_pooling", "tumorprop_threshold",  "max_iter_outer", "nodepotential", "initialization_method", "num_hmrf_initialization_start",  "num_hmrf_initialization_end", "spatial_weight", "construct_adjacency_method", "construct_adjacency_w"], \
                          ["n_states", "params", "t", "t_phaseing", "fix_NB_dispersion", "shared_NB_dispersion", "fix_BB_dispersion", "shared_BB_dispersion", "max_iter", "tol", "gmm_random_state", "np_threshold", "np_eventminlen"], \

--- a/src/calicost/calicost_main.py
+++ b/src/calicost/calicost_main.py
@@ -136,8 +136,8 @@ def main(configuration_file):
                         break
             # filter bins based on normal
             index_normal = np.where(normal_candidate)[0]
-            lengths, single_X, single_base_nb_mean, single_total_bb_RD, log_sitewise_transmat, df_gene_snp = bin_selection_basedon_normal(df_gene_snp, \
-                single_X, single_base_nb_mean, single_total_bb_RD, config['nu'], config['logphase_shift'], index_normal, config['geneticmap_file'])
+            # lengths, single_X, single_base_nb_mean, single_total_bb_RD, log_sitewise_transmat, df_gene_snp = bin_selection_basedon_normal(df_gene_snp, \
+            #     single_X, single_base_nb_mean, single_total_bb_RD, config['nu'], config['logphase_shift'], index_normal, config['geneticmap_file'])
             assert df_bininfo.shape[0] == copy_single_X_rdr.shape[0]
             df_bininfo = genesnp_to_bininfo(df_gene_snp)
             copy_single_X_rdr = copy.copy(single_X[:,0,:])

--- a/src/calicost/hmm_NB_BB_phaseswitch.py
+++ b/src/calicost/hmm_NB_BB_phaseswitch.py
@@ -716,7 +716,7 @@ def similarity_components_rdrbaf_neymanpearson(X, base_nb_mean, total_bb_RD, res
     new_assignment = np.array([map_clone_id[x] for x in res["new_assignment"]])
     merged_res = copy.copy(res)
     merged_res["new_assignment"] = new_assignment
-    merged_res["total_llf"] = np.NAN
+    merged_res["total_llf"] = np.nan
     merged_res["pred_cnv"] = np.concatenate([ res["pred_cnv"][(c[0]*n_obs):(c[0]*n_obs+n_obs)] for c in merging_groups ])
     merged_res["log_gamma"] = np.hstack([ res["log_gamma"][:, (c[0]*n_obs):(c[0]*n_obs+n_obs)] for c in merging_groups ])
     return merging_groups, merged_res

--- a/src/calicost/hmrf.py
+++ b/src/calicost/hmrf.py
@@ -290,7 +290,7 @@ def merge_by_minspots(assignment, res, single_total_bb_RD, min_spots_thresholds=
     #     unique_assignment = np.unique(new_assignment)
     merged_res = copy.copy(res)
     merged_res["new_assignment"] = new_assignment
-    merged_res["total_llf"] = np.NAN
+    merged_res["total_llf"] = np.nan
     merged_res["pred_cnv"] = np.concatenate([ res["pred_cnv"][(c[0]*n_obs):(c[0]*n_obs+n_obs)] for c in merging_groups ])
     merged_res["log_gamma"] = np.hstack([ res["log_gamma"][:, (c[0]*n_obs):(c[0]*n_obs+n_obs)] for c in merging_groups ])
     return merging_groups, merged_res

--- a/src/calicost/parse_input.py
+++ b/src/calicost/parse_input.py
@@ -96,7 +96,7 @@ def parse_visium(config):
     cell_snp_Aallele = cell_snp_Aallele[:, idx_snps_within]
     cell_snp_Ballele = cell_snp_Ballele[:, idx_snps_within]
     unique_snp_ids = unique_snp_ids[idx_snps_within]
-    df_gene_snp = create_haplotype_block_ranges(df_gene_snp, adata, cell_snp_Aallele, cell_snp_Ballele, unique_snp_ids)
+    df_gene_snp = create_haplotype_block_ranges(df_gene_snp, adata, cell_snp_Aallele, cell_snp_Ballele, unique_snp_ids, initial_min_umi=config['initial_min_umi'])
     # lengths, single_X, single_base_nb_mean, single_total_bb_RD, log_sitewise_transmat = summarize_counts_for_blocks(df_gene_snp, \
     #         adata, cell_snp_Aallele, cell_snp_Ballele, unique_snp_ids, nu=config['nu'], logphase_shift=config['logphase_shift'], geneticmap_file=config['geneticmap_file'])
     # # infer an initial phase using pseudobulk

--- a/src/calicost/parse_input.py
+++ b/src/calicost/parse_input.py
@@ -124,14 +124,15 @@ def parse_visium(config):
     else:
         df_gene_snp = pd.read_pickle(f"{config['output_dir']}/parsed_inputs/df_gene_snp_combinegenesnps.pkl")
 
-    idx_snps_within = np.where(df_gene_snp[~df_gene_snp.is_interval].gene.notnull())[0]
-    df_gene_snp = df_gene_snp[df_gene_snp.gene.notnull()]
-    cell_snp_Aallele = cell_snp_Aallele[:, idx_snps_within]
-    cell_snp_Ballele = cell_snp_Ballele[:, idx_snps_within]
-    unique_snp_ids = unique_snp_ids[idx_snps_within]
+    # # TBD: need to set another user parameters to decide whether only restricted to SNPs within df_hgtable
+    # idx_snps_within = np.where(df_gene_snp[~df_gene_snp.is_interval].gene.notnull())[0]
+    # df_gene_snp = df_gene_snp[df_gene_snp.gene.notnull()]
+    # cell_snp_Aallele = cell_snp_Aallele[:, idx_snps_within]
+    # cell_snp_Ballele = cell_snp_Ballele[:, idx_snps_within]
+    # unique_snp_ids = unique_snp_ids[idx_snps_within]
 
     if not Path(f"{config['output_dir']}/parsed_inputs/df_gene_snp_haplotypeblock.pkl").exists():
-        df_gene_snp = create_haplotype_block_ranges(df_gene_snp, adata, cell_snp_Aallele, cell_snp_Ballele, unique_snp_ids, initial_min_umi=config['initial_min_umi'])
+        df_gene_snp = create_haplotype_block_ranges(df_gene_snp, adata, cell_snp_Aallele, cell_snp_Ballele, unique_snp_ids, htblock_min_snps=config['htblock_min_snps'], htblock_min_umi=config['initial_min_umi'])
         # save temp output
         df_gene_snp.to_pickle(f"{config['output_dir']}/parsed_inputs/df_gene_snp_haplotypeblock.pkl")
     else:

--- a/src/calicost/phasing.py
+++ b/src/calicost/phasing.py
@@ -69,15 +69,15 @@ def initial_phase_given_partition(sp_single_X_b, lengths, sp_single_total_bb_RD,
         base_nb_mean = np.zeros(total_bb_RD.shape)
         tumor_prop = None
     else:
-        filtered_initial_clone_index = [ x[sintle_tumor_prop[x] > threshold] for x in initial_clone_index ]
+        filtered_initial_clone_index = [ x[single_tumor_prop[x] > threshold] for x in initial_clone_index ]
         idx_row = np.concatenate(filtered_initial_clone_index)
         idx_col = np.concatenate([ [i] * len(x) for i,x in enumerate(filtered_initial_clone_index) ])
-        mul = scipy.sparse.csr_matrix((np.ones(sp_single_X_b.shape[1]), (idx_row, idx_col)), shape=(sp_single_X_b.shape[1], len(initial_clone_index)))
-        X = np.zeros((sp_single_X_b.shape[0], 2, len(initial_clone_index)))
-        X[:,1,:] = sp_single_X_b @ mul
-        total_bb_RD = sp_single_total_bb_RD @ mul
+        mul = scipy.sparse.csr_matrix((np.ones(len(idx_row)), (idx_row, idx_col)), shape=(sp_single_X_b.shape[1], len(filtered_initial_clone_index)))
+        X = np.zeros((sp_single_X_b.shape[0], 2, len(filtered_initial_clone_index)))
+        X[:,1,:] = (sp_single_X_b @ mul).toarray()
+        total_bb_RD = (sp_single_total_bb_RD @ mul).toarray()
         base_nb_mean = np.zeros(total_bb_RD.shape)
-        tumor_prop = single_tumor_prop @ mul
+        tumor_prop = single_tumor_prop.values @ mul
 
     # pseudobulk HMM for phase_prob
     baf_profiles = np.zeros((X.shape[2], X.shape[0]))

--- a/src/calicost/plot_spatial_clones.py
+++ b/src/calicost/plot_spatial_clones.py
@@ -1,0 +1,114 @@
+import sys
+import argparse
+
+import numpy as np
+import scipy
+import pandas as pd
+from itertools import cycle
+import matplotlib
+from matplotlib import pyplot as plt
+from matplotlib.colors import LinearSegmentedColormap, ListedColormap
+from matplotlib.gridspec import GridSpec
+import seaborn
+from matplotlib.lines import Line2D
+import matplotlib.patches as mpatches
+
+from calicost.arg_parse import *
+from calicost.parse_input import *
+from calicost.utils_plotting import *
+
+
+def plot_individual_spots_in_space_updated(coords, assignment, single_tumor_prop=None, sample_list=None, sample_ids=None, base_width=4, base_height=3, point_size=10, palette="Set2"):
+    # combine coordinates across samples
+    shifted_coords = copy.copy(coords)
+    if not (sample_ids is None):
+        x_offset = 0
+        for s,sname in enumerate(sample_list):
+            index = np.where(sample_ids == s)[0]
+            shifted_coords[index,0] = shifted_coords[index,0] + x_offset
+            x_offset += np.max(coords[index,0]) + 10
+
+    # number of clones and samples
+    final_clone_ids = np.unique(assignment[~assignment.isnull()].values)
+    n_final_clones = len(final_clone_ids)
+    n_samples = 1 if sample_list is None else len(sample_list)
+
+    # remove nan of single_tumor_prop
+    if not single_tumor_prop is None:
+        copy_single_tumor_prop = copy.copy(single_tumor_prop)
+        copy_single_tumor_prop[np.isnan(copy_single_tumor_prop)] = 0.5
+    
+    fig, axes = plt.subplots(1, 1, figsize=(base_width*n_samples, base_height), dpi=200, facecolor="white")
+    if "clone 0" in final_clone_ids:
+        colorlist = ['lightgrey'] + seaborn.color_palette(palette, n_final_clones-1).as_hex()
+    else:
+        colorlist = seaborn.color_palette(palette, n_final_clones).as_hex()
+
+    for c,cid in enumerate(final_clone_ids):
+        idx = np.where( (assignment.values==cid) )[0]
+        if single_tumor_prop is None:
+            seaborn.scatterplot(x=shifted_coords[idx,0], y=-shifted_coords[idx,1], s=point_size, color=colorlist[c], linewidth=0, legend=None, ax=axes)
+        else:
+            # cmap
+            this_full_cmap = seaborn.color_palette(f"blend:lightgrey,{colorlist[c]}", as_cmap=True)
+            quantile_colors = this_full_cmap(np.array([0, np.min(copy_single_tumor_prop[idx]), np.max(copy_single_tumor_prop[idx]), 1]))
+            quantile_colors = [matplotlib.colors.rgb2hex(x) for x in quantile_colors[1:-1]]
+            this_cmap = seaborn.color_palette(f"blend:{quantile_colors[0]},{quantile_colors[-1]}", as_cmap=True)
+            seaborn.scatterplot(x=shifted_coords[idx,0], y=-shifted_coords[idx,1], s=point_size, hue=copy_single_tumor_prop[idx], palette=this_cmap, linewidth=0, legend=None, ax=axes)
+
+    legend_elements = [Line2D([0], [0], marker='o', color="w", markerfacecolor=colorlist[c], label=cid, markersize=10) for c,cid in enumerate(final_clone_ids)]
+    axes.legend(legend_elements, final_clone_ids, handlelength=0.1, loc="upper left", bbox_to_anchor=(1,1))
+    axes.axis("off")
+
+    fig.tight_layout()
+    return fig
+
+
+def main(configuration_file, output_file, r_hmrf_initialization=None, base_width=4, base_height=3, point_size=20, palette='Set2'):
+    """
+    Plot clones in space based on existing CalicoST output (output_dir/clone<n_clones>_rectangle<r_hmrf_initialization>_w<spatial_weight>/clone_labels.tsv)
+    
+    :param configuration_file: Path to the configuration file
+    :param output_file: Path to the output file
+    :param base_width: Width of the figure
+    :param base_height: Height of the figure
+    :param point_size: Size of the points
+    :param palette: Color palette
+    """
+    # Load configuration
+    try:
+        config = read_configuration_file(configuration_file)
+    except:
+        config = read_joint_configuration_file(configuration_file)
+    
+    # Load data
+    lengths, single_X, single_base_nb_mean, single_total_bb_RD, log_sitewise_transmat, df_bininfo, df_gene_snp, \
+        barcodes, coords, single_tumor_prop, sample_list, sample_ids, adjacency_mat, smooth_mat, exp_counts = run_parse_n_load(config)
+
+    # Load results and plot
+    if r_hmrf_initialization is None:
+        r_hmrf_initialization = config["num_hmrf_initialization_start"]
+    
+    outdir = f"{config['output_dir']}/clone{config['n_clones']}_rectangle{r_hmrf_initialization}_w{config['spatial_weight']:.1f}"
+    assert Path(outdir).is_dir(), f"Directory {outdir} does not exist. Did you run CalicoST with the same random seed 'num_hmrf_initialization_start'?"
+
+    df_clone_label = pd.read_csv(f"{outdir}/clone_labels.tsv", header=0, index_col=0, sep="\t")
+    assignment = pd.Series([f"clone {x}" for x in df_clone_label.clone_label.values])
+
+    fig = plot_individual_spots_in_space_updated(coords, assignment, single_tumor_prop, sample_list=sample_list, sample_ids=sample_ids,
+                                                    base_width=base_width, base_height=base_height, point_size=point_size, palette=palette)
+    fig.savefig(output_file, transparent=True, bbox_inches="tight")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Plot clones in space based on existing CalicoST output")
+    parser.add_argument("-c", "--configfile", help="configuration file of CalicoST", required=True, type=str)
+    parser.add_argument("--output_file", type=str, help="Path to the output file")
+    parser.add_argument("--r_hmrf_initialization", type=int, default=None, help="Random seed for HMRF initialization")
+    parser.add_argument("--base_width", type=float, default=4, help="Width of the figure")
+    parser.add_argument("--base_height", type=float, default=3, help="Height of the figure")
+    parser.add_argument("--point_size", type=int, default=20, help="Size of the points")
+    parser.add_argument("--palette", type=str, default="Set2", help="Color palette")
+    args = parser.parse_args()
+
+    main(args.configfile, args.output_file, args.r_hmrf_initialization, args.base_width, args.base_height, args.point_size, args.palette)

--- a/src/calicost/utils_IO.py
+++ b/src/calicost/utils_IO.py
@@ -22,7 +22,7 @@ import subprocess
 def load_data(spaceranger_dir, snp_dir, filtergenelist_file, filterregion_file, normalidx_file, min_snpumis=50, min_percent_expressed_spots=0.005):
     ##### read raw UMI count matrix #####
     if Path(f"{spaceranger_dir}/filtered_feature_bc_matrix.h5").exists():
-        adata = sc.read_10x_h5(f"{spaceranger_dir}/filtered_feature_bc_matrix.h5")
+        adata = sc.read_10x_h5(f"{spaceranger_dir}/filtered_feature_bc_matrix.h5", gex_only=False)
     elif Path(f"{spaceranger_dir}/filtered_feature_bc_matrix.h5ad").exists():
         adata = sc.read_h5ad(f"{spaceranger_dir}/filtered_feature_bc_matrix.h5ad")
     else:
@@ -150,7 +150,7 @@ def load_joint_data(input_filelist, snp_dir, alignment_files, filtergenelist_fil
         df_this_barcode.index = df_this_barcode.barcode
         # read adata count info
         if Path(f"{df_meta['spaceranger_dir'].iloc[i]}/filtered_feature_bc_matrix.h5").exists():
-            adatatmp = sc.read_10x_h5(f"{df_meta['spaceranger_dir'].iloc[i]}/filtered_feature_bc_matrix.h5")
+            adatatmp = sc.read_10x_h5(f"{df_meta['spaceranger_dir'].iloc[i]}/filtered_feature_bc_matrix.h5", gex_only=False)
         elif Path(f"{df_meta['spaceranger_dir'].iloc[i]}/filtered_feature_bc_matrix.h5ad").exists():
             adatatmp = sc.read_h5ad(f"{df_meta['spaceranger_dir'].iloc[i]}/filtered_feature_bc_matrix.h5ad")
         else:

--- a/src/calicost/utils_IO.py
+++ b/src/calicost/utils_IO.py
@@ -52,6 +52,7 @@ def load_data(spaceranger_dir, snp_dir, filtergenelist_file, filterregion_file, 
     df_pos.barcode = pd.Categorical(df_pos.barcode, categories=list(adata.obs.index), ordered=True)
     df_pos.sort_values(by="barcode", inplace=True)
     adata.obsm["X_pos"] = np.vstack([df_pos.x, df_pos.y]).T
+    adata.var_names_make_unique()
 
     # shared barcodes between adata and SNPs
     shared_barcodes = set(list(snp_barcodes.barcodes)) & set(list(adata.obs.index))
@@ -529,10 +530,9 @@ def combine_gene_snps(unique_snp_ids, hgtable_file, adata):
         if i == 0:
             continue
         this_pos = vec_start[i]
+        last_j = next((j for j in range(last_j, len(gene_chr)) if gene_chr[j] > vec_chr[i] or (gene_chr[j] == vec_chr[i] and gene_end[j] > this_pos)), len(gene_chr))
         j = last_j
-        while j < len(gene_chr) and (gene_chr[j] < vec_chr[i] or (gene_chr[j] == vec_chr[i] and gene_end[j] <= this_pos)):
-            j += 1
-        while j < len(gene_chr) and j >= last_j and gene_chr[j] == vec_chr[i]:
+        while j < len(gene_chr) and gene_chr[j] == vec_chr[i] and gene_start[j] <= this_pos:
             if gene_chr[j] == vec_chr[i] and gene_start[j] <= this_pos and gene_end[j] > this_pos:
                 vec_genes[i] = gene_names[j]
                 last_j = j
@@ -563,7 +563,7 @@ def combine_gene_snps(unique_snp_ids, hgtable_file, adata):
     return df_gene_snp
 
 
-def create_haplotype_block_ranges(df_gene_snp, adata, cell_snp_Aallele, cell_snp_Ballele, unique_snp_ids, initial_min_umi=15):
+def create_haplotype_block_ranges(df_gene_snp, adata, cell_snp_Aallele, cell_snp_Ballele, unique_snp_ids, htblock_min_snps=1, htblock_min_umi=15):
     """
     Initially block SNPs along genome.
 
@@ -573,7 +573,8 @@ def create_haplotype_block_ranges(df_gene_snp, adata, cell_snp_Aallele, cell_snp
         Gene and SNP info combined into a single data frame sorted by genomic positions. "is_interval" suggest whether the entry is a gene or a SNP. "gene" column either contain gene name if the entry is a gene, or the gene a SNP belongs to if the entry is a SNP.
     """
     # first level: partition of genome: by gene regions (if two genes overlap, they are grouped to one region)
-    tmp_block_genome_intervals = list(zip( df_gene_snp[df_gene_snp.is_interval].CHR.values, df_gene_snp[df_gene_snp.is_interval].START.values, df_gene_snp[df_gene_snp.is_interval].END.values ))
+    # tmp_block_genome_intervals = list(zip( df_gene_snp[df_gene_snp.is_interval].CHR.values, df_gene_snp[df_gene_snp.is_interval].START.values, df_gene_snp[df_gene_snp.is_interval].END.values ))
+    tmp_block_genome_intervals = list(zip( df_gene_snp.CHR.values, df_gene_snp.START.values, df_gene_snp.END.values ))
     block_genome_intervals = [tmp_block_genome_intervals[0]]
     for x in tmp_block_genome_intervals[1:]:
         # check whether overlap with previous block
@@ -598,17 +599,22 @@ def create_haplotype_block_ranges(df_gene_snp, adata, cell_snp_Aallele, cell_snp
     initial_block_id = np.zeros(df_gene_snp.shape[0], dtype=int)
     for i,x in enumerate(block_ranges):
         initial_block_id[x[0]:x[1]] = i
+    if not np.all(initial_block_id[:-1] <= initial_block_id[1:]):
+        i = np.where(initial_block_id[:-1] > initial_block_id[1:])[0][0]
+        logger.error(f"Not all genes/SNPs are assigned to initial blocks properly. {df_gene_snp.iloc[i:(i+2),:]}, {initial_block_id[i:(i+2)]}")
     df_gene_snp["initial_block_id"] = initial_block_id
 
-    # second level: group the first level blocks into haplotype blocks such that the minimum SNP-covering UMI counts >= initial_min_umi
+    # second level: group the first level blocks into haplotype blocks such that the minimum SNP-covering UMI counts >= htblock_min_umi
     snpumi = np.zeros(df_gene_snp.shape[0], dtype=int)
     snpumi[~df_gene_snp.is_interval] = np.sum(cell_snp_Aallele, axis=0).A.flatten() + np.sum(cell_snp_Ballele, axis=0).A.flatten()
     cumsum_snpumi = np.append(0, np.cumsum(snpumi))
+    count_num_snps = np.append(0, np.cumsum((~df_gene_snp.is_interval).values))
     block_ranges_new = []
     s = 0
     while s < df_gene_snp.shape[0]:
         s_initial_block = df_gene_snp.initial_block_id.values[s]
         t_initial_block = s_initial_block + 1
+        # t_initial_block = s_initial_block + htblock_min_snps
         t = next((s + i for i in range(len(initial_block_id[s:])) if initial_block_id[s+i] >= t_initial_block), df_gene_snp.shape[0])
         while t_initial_block <= len(block_ranges):
             # t = s + np.where(initial_block_id[s:] < t_initial_block)[0][-1] + 1
@@ -616,6 +622,7 @@ def create_haplotype_block_ranges(df_gene_snp, adata, cell_snp_Aallele, cell_snp
             change_chr = (df_gene_snp.CHR.values[s] != df_gene_snp.CHR.values[t-1])
             # check snp UMIs
             this_snp_umis = cumsum_snpumi[t] - cumsum_snpumi[s]
+            this_num_snps = count_num_snps[t] - count_num_snps[s]
             if reach_end:
                 break
             if change_chr:
@@ -623,13 +630,14 @@ def create_haplotype_block_ranges(df_gene_snp, adata, cell_snp_Aallele, cell_snp
                 # t = np.where(initial_block_id < t_initial_block)[0][-1] + 1
                 t = next((s + i for i in range(len(initial_block_id[s:])) if initial_block_id[s+i] >= t_initial_block), df_gene_snp.shape[0])
                 this_snp_umis = cumsum_snpumi[t] - cumsum_snpumi[s]
+                this_num_snps = count_num_snps[t] - count_num_snps[s]
                 break
-            if this_snp_umis >= initial_min_umi:
+            if this_snp_umis >= htblock_min_umi and this_num_snps >= htblock_min_snps:
                 break
             t_initial_block += 1
             t = next((s + i for i in range(len(initial_block_id[s:])) if initial_block_id[s+i] >= t_initial_block), df_gene_snp.shape[0])
         #
-        if this_snp_umis < initial_min_umi and s > 0 and df_gene_snp.CHR.values[s-1] == df_gene_snp.CHR.values[s]:
+        if this_snp_umis < htblock_min_umi and s > 0 and df_gene_snp.CHR.values[s-1] == df_gene_snp.CHR.values[s]:
             block_ranges_new[-1] = (block_ranges_new[-1][0], t)
         else:
             block_ranges_new.append( (s, t) )
@@ -660,10 +668,10 @@ def create_haplotype_block_ranges(df_gene_snp, adata, cell_snp_Aallele, cell_snp
     #             involved_snp_idx = np.array([map_snp_index[x] for x in involved_snps_ids])
     #             this_snp_umis = 0 if len(involved_snp_idx) == 0 else np.sum( cell_snp_Aallele[:, involved_snp_idx]) + np.sum(cell_snp_Ballele[:, involved_snp_idx])
     #             break
-    #         if this_snp_umis >= initial_min_umi:
+    #         if this_snp_umis >= htblock_min_umi:
     #             break
     #     #
-    #     if this_snp_umis < initial_min_umi and s > 0 and initial_block_chr[s-1] == initial_block_chr[s]:
+    #     if this_snp_umis < htblock_min_umi and s > 0 and initial_block_chr[s-1] == initial_block_chr[s]:
     #         indexes = np.where(df_gene_snp.initial_block_id.isin(np.arange(s, t)))[0]
     #         block_ranges_new[-1] = (block_ranges_new[-1][0], indexes[-1]+1)
     #     else:
@@ -733,7 +741,7 @@ def summarize_counts_for_blocks(df_gene_snp, adata, cell_snp_Aallele, cell_snp_B
     sorted_chr_pos_first = list(zip(sorted_chr_pos_first.CHR.values, sorted_chr_pos_first.START.values))
     sorted_chr_pos_last = df_gene_snp.groupby('block_id').agg({'CHR': 'last', 'END': 'last'})
     sorted_chr_pos_last = list(zip(sorted_chr_pos_last.CHR.values, sorted_chr_pos_last.END.values))
-    #
+    
     tmp_sorted_chr_pos = [val for pair in zip(sorted_chr_pos_first, sorted_chr_pos_last) for val in pair]
     position_cM = get_position_cM_table( tmp_sorted_chr_pos, geneticmap_file )
     phase_switch_prob = compute_phase_switch_probability_position(position_cM, tmp_sorted_chr_pos, nu)
@@ -1078,12 +1086,25 @@ def summarize_counts_for_bins(df_gene_snp, sp_single_X_rdr, sp_single_X_b, sp_si
     #     involved_genes = [x for x in df_bin_contents.gene.values[b] if not x is None]
     #     bin_single_X[b, 0, :] = np.sum( adata.layers['count'][:, adata.var.index.isin(involved_genes)], axis=1 )
 
+    # incorporate phase indicator into B allele count and generate phased_sp_single_X_b
+    # collect all nonzero entries in sp_single_total_bb_RD, collect the corresponding B count from sp_single_X_b
+    df_allele_count = pd.DataFrame({'row':sp_single_total_bb_RD.nonzero()[0], 
+                                   'col':sp_single_total_bb_RD.nonzero()[1], 
+                                   'val':sp_single_total_bb_RD[sp_single_total_bb_RD.nonzero()].A.flatten()})
+    df_allele_count['unphased_B'] = sp_single_X_b[ (df_allele_count.row, df_allele_count.col) ].A.flatten()
+    # add phase indicator information
+    df_allele_count['phase_indicator'] = phase_indicator[ df_allele_count.row.values ]
+    # get phased B count
+    df_allele_count['phased_B'] = np.where(df_allele_count.phase_indicator, df_allele_count.unphased_B, df_allele_count.val - df_allele_count.unphased_B)
+    # create phased_sp_single_X_b
+    phased_sp_single_X_b = scipy.sparse.csr_matrix((df_allele_count.phased_B.values, (df_allele_count.row.values, df_allele_count.col.values)), shape=sp_single_X_b.shape)
+
     n_bins = len(df_gene_snp.bin_id.unique())
     N = sp_single_X_rdr.shape[1]
     mul = scipy.sparse.csr_matrix((np.ones(df_gene_snp.shape[0]), (df_gene_snp.bin_id, df_gene_snp.block_id)) )
     bin_single_X = np.zeros((n_bins, 2, N))
     bin_single_X[:,0,:] = (mul @ sp_single_X_rdr).toarray()
-    bin_single_X[:,1,:] = (mul @ sp_single_X_b).toarray()
+    bin_single_X[:,1,:] = (mul @ phased_sp_single_X_b).toarray()
     bin_single_total_bb_RD = (mul @ sp_single_total_bb_RD).toarray()
     bin_single_base_nb_mean = np.zeros(bin_single_total_bb_RD.shape)
 

--- a/src/calicost/utils_hmrf.py
+++ b/src/calicost/utils_hmrf.py
@@ -140,6 +140,55 @@ def choose_adjacency_by_KNN(coords, exp_counts=None, w=1, maxspots_pooling=7):
     return smooth_mat, adjacency_mat
 
 
+def choose_adjacency_by_triangulation(coords, maxspots_pooling=7):
+    """
+    Create adjacency matrix by delauney triangulation, and then expand the adjacency matrix by allow 2-step and 3-step edges until the number of adjacent spots gets close to maxspots_pooling.
+
+    Attributes
+    ----------
+    coords : array, shape (n_spots, 2)
+        Spatial coordinates of spots.
+
+    maxspots_pooling : int
+        Maximum number of adjacent spots.
+    """
+    # delauney triangulation
+    delaunay = scipy.spatial.Delaunay(coords)
+    num_points = coords.shape[0]
+    
+    # Use a set to store edges to avoid duplicates
+    edges_set = set()
+    for simplex in delaunay.simplices:
+        for i in range(len(simplex)):
+            for j in range(i + 1, len(simplex)):
+                edges_set.add(tuple(sorted((simplex[i], simplex[j]))))
+    
+    # Convert the set of edges to a list of tuples
+    edges = list(edges_set)
+    
+    # Create row and column indices for the adjacency matrix
+    row_ind = [edge[0] for edge in edges]
+    col_ind = [edge[1] for edge in edges]
+    
+    # Create the adjacency matrix in CSR format
+    adjacency_matrix = scipy.sparse.csr_matrix((np.ones(len(edges)), (row_ind, col_ind)), shape=(num_points, num_points))
+
+    # make sure the adjacency matrix is symmetric
+    adjacency_matrix = (adjacency_matrix + adjacency_matrix.T).astype(bool)
+    
+    # Make the adjacency matrix symmetric (undirected graph)
+    adjacency_matrix = adjacency_matrix + adjacency_matrix.T
+    adjacency_matrix = (adjacency_matrix > 0).astype(int) # Ensure values are 0 or 1
+
+    # Expand the adjacency matrix by allow 2-step, 3-step, and more edges
+    expand_adjacency_matrix = (adjacency_matrix @ adjacency_matrix).astype(bool)
+    while np.median(np.sum(expand_adjacency_matrix, axis=0).A1) < maxspots_pooling:
+        adjacency_matrix = expand_adjacency_matrix
+        expand_adjacency_matrix = (expand_adjacency_matrix @ adjacency_matrix).astype(bool)
+    
+    return adjacency_matrix, expand_adjacency_matrix - adjacency_matrix
+
+
 def choose_adjacency_by_readcounts_slidedna(coords, maxspots_pooling=30):
     """
     Merge spots such that 95% quantile of read count per SNP per spot exceed count_threshold.
@@ -157,21 +206,23 @@ def multislice_adjacency(sample_ids, sample_list, coords, single_total_bb_RD, ex
         index = np.where(sample_ids == i)[0]
         this_coords = np.array(coords[index,:])
         if construct_adjacency_method == "hexagon":
-            tmpsmooth_mat, tmpadjacency_mat = choose_adjacency_by_readcounts(this_coords, single_total_bb_RD[:,index], maxspots_pooling=maxspots_pooling)
+            try:
+                tmpsmooth_mat, tmpadjacency_mat = choose_adjacency_by_readcounts(this_coords, single_total_bb_RD[:,index], maxspots_pooling=maxspots_pooling)
+            # catch memory error, and then use choose_adjacency_by_triangulation
+            except MemoryError:
+                tmpsmooth_mat, tmpadjacency_mat = choose_adjacency_by_triangulation(this_coords, maxspots_pooling=maxspots_pooling)
         elif construct_adjacency_method == "KNN":
             # tmpsmooth_mat, tmpadjacency_mat = choose_adjacency_by_KNN(this_coords, exp_counts.iloc[index,:], w=construct_adjacency_w, maxspots_pooling=maxspots_pooling)
             tmpsmooth_mat, tmpadjacency_mat = choose_adjacency_by_KNN(this_coords, exp_counts[index,:], w=construct_adjacency_w, maxspots_pooling=maxspots_pooling)
         else:
             raise("Unknown adjacency construction method")
         # tmpsmooth_mat, tmpadjacency_mat = choose_adjacency_by_readcounts_slidedna(this_coords, maxspots_pooling=config["maxspots_pooling"])
-        adjacency_mat.append( tmpadjacency_mat.A )
-        smooth_mat.append( tmpsmooth_mat.A )
-    adjacency_mat = scipy.linalg.block_diag(*adjacency_mat)
-    adjacency_mat = scipy.sparse.csr_matrix( adjacency_mat )
+        adjacency_mat.append( tmpadjacency_mat )
+        smooth_mat.append( tmpsmooth_mat )
+    adjacency_mat = scipy.sparse.block_diag(adjacency_mat, format='csr')
     if not across_slice_adjacency_mat is None:
         adjacency_mat += across_slice_adjacency_mat
-    smooth_mat = scipy.linalg.block_diag(*smooth_mat)
-    smooth_mat = scipy.sparse.csr_matrix( smooth_mat )
+    smooth_mat = scipy.sparse.block_diag(smooth_mat, format='csr')
     return adjacency_mat, smooth_mat
 
 
@@ -648,15 +699,15 @@ def estimator_tumor_proportion(single_X, single_total_bb_RD, assignments, pred_c
     ----------
     0.5 ( 1-theta ) / (theta * RDR + 1 - theta) = B_count / Total_count for each LOH state.
     """
-    # def estimate_purity(T_loh, B_loh, rdr_values):
-    #     features =(T_loh / 2.0 + rdr_values * B_loh - B_loh)[T_loh>0].reshape(-1,1)
-    #     y = (T_loh / 2.0 - B_loh)[T_loh>0]
-    #     return np.linalg.lstsq(features, y, rcond=None)[0]
     def estimate_purity(T_loh, B_loh, rdr_values):
-        idx = np.where(T_loh > 0)[0]
-        model = BAF_Binom(endog=B_loh[idx], exog=np.ones((len(idx),1)), weights=np.ones(len(idx)), exposure=T_loh[idx], offset=np.log(rdr_values[idx]), scaling=0.5)
-        res = model.fit(disp=False)
-        return 1.0 / (1.0 + np.exp(res.params))
+        features =(T_loh / 2.0 + rdr_values * B_loh - B_loh)[T_loh>0].reshape(-1,1)
+        y = (T_loh / 2.0 - B_loh)[T_loh>0]
+        return np.linalg.lstsq(features, y, rcond=None)[0]
+    # def estimate_purity(T_loh, B_loh, rdr_values):
+    #     idx = np.where(T_loh > 0)[0]
+    #     model = BAF_Binom(endog=B_loh[idx], exog=np.ones((len(idx),1)), weights=np.ones(len(idx)), exposure=T_loh[idx], offset=np.log(rdr_values[idx]), scaling=0.5)
+    #     res = model.fit(disp=False)
+    #     return 1.0 / (1.0 + np.exp(res.params))
     #
     n_obs = single_X.shape[0]
     n_spots = single_X.shape[2]

--- a/utils/subsample.py
+++ b/utils/subsample.py
@@ -1,0 +1,201 @@
+import sys
+import numpy as np
+import scipy
+import pandas as pd
+from pathlib import Path
+import scanpy as sc
+import argparse
+
+
+def subsample_cells_multi(input_filelist, outputdir, n_cells, random_seed=0):
+    """
+    Sub-sample cells from a list of spaceranger output directories.
+
+    Parameters
+    ----------
+    input_filelist : str
+        Path to a file containing a list of spaceranger output directories. Columns: bam, sample_id, spaceranger_dir
+
+    outputdir : str
+        Directory to save the subsampled h5ad files.
+
+    n_cells : int
+        Number of cells to subsample.
+    """
+    df_meta = pd.read_csv(input_filelist, sep="\t", header=None)
+    df_meta.rename(columns=dict(zip( df_meta.columns[:3], ["bam", "sample_id", "spaceranger_dir"] )), inplace=True)
+    
+    # get the full list of barcodes by reading tissue_positions.csv or tissue_positions_list.csv file from each spaceranger directory
+    df_pos = []
+    for i, spaceranger in enumerate(df_meta.spaceranger_dir.values):
+        pos_file = Path(spaceranger) / "spatial" / "tissue_positions.csv"
+        if not pos_file.exists():
+            pos_file = Path(spaceranger) / "spatial" / "tissue_positions_list.csv"
+            this_pos = pd.read_csv(pos_file, sep=",", header=None, names=["barcode", "in_tissue", "x", "y", "pixel_row", "pixel_col"])
+        else:
+            this_pos = pd.read_csv(pos_file, sep=",", header=0, names=["barcode", "in_tissue", "x", "y", "pixel_row", "pixel_col"])
+        
+        this_pos = this_pos[this_pos.in_tissue == True]
+        this_pos['sampleid'] = df_meta.sample_id.values[i]
+
+        this_pos.barcode = this_pos.barcode + '_' + this_pos['sampleid']
+        df_pos.append(this_pos)
+
+    df_pos = pd.concat(df_pos, ignore_index=True)
+
+    # compute the number of cells to subsample from each sample based on the number of cells in each sample
+    n_cells_per_sample = np.round(n_cells * df_pos.groupby('sampleid').size() / df_pos.shape[0]).astype(int)
+
+    # subsample cells randomly uniformly from each sample
+    np.random.seed(random_seed)
+    df_sampled = []
+    for i, sampleid in enumerate(df_meta.sample_id.values):
+        this_sample = df_pos[df_pos.sampleid == sampleid].sample(n=n_cells_per_sample[i], replace=False)
+        this_sample.sort_index(inplace=True)
+        df_sampled.append(this_sample)
+    df_sampled = pd.concat(df_sampled, ignore_index=True)
+
+    # write a new h5ad file with the subsampled cells and the corresponding tissue_positions.csv file
+    for i, spaceranger in enumerate(df_meta.spaceranger_dir.values):
+        if Path(f'{spaceranger}/filtered_feature_bc_matrix.h5').exists():
+            adata = sc.read_10x_h5(f'{spaceranger}/filtered_feature_bc_matrix.h5', gex_only=False)
+        else:
+            adata = sc.read_h5ad(f'{spaceranger}/filtered_feature_bc_matrix.h5ad')
+        this_pos = df_sampled[df_sampled.sampleid == df_meta.sample_id.values[i]].drop(columns='sampleid')
+        this_pos.barcode = this_pos.barcode.str.split('_').str[0]
+        adata = adata[this_pos.barcode.values, :]
+        # write the subsampled h5ad file
+        # mkdir
+        sample_outdir = Path(outputdir) / df_meta.sample_id.values[i]
+        sample_outdir.mkdir(parents=True, exist_ok=True)
+        adata.write(sample_outdir / "filtered_feature_bc_matrix.h5ad")
+        # write the subsampled tissue_positions.csv file
+        sample_outdir2 = sample_outdir / 'spatial'
+        sample_outdir2.mkdir(parents=True, exist_ok=True)
+        this_pos.to_csv(sample_outdir2 / "tissue_positions.csv", sep=",", index=False, header=True)
+
+    return df_sampled
+
+
+def subsample_cells_single(spaceranger_dir, outputdir, n_cells, random_seed=0):
+    """
+    Sub-sample cells from a single spaceranger output directory.
+
+    Parameters
+    ----------
+    spaceranger_dir : str
+        Path to the spaceranger output directory.
+    outputdir : str
+        Directory to save the subsampled h5ad files.
+    n_cells : int
+        Number of cells to subsample.
+    """
+    # get the list of spot barcodes by reading the tissue_positions.csv or tissue_positions_list.csv file
+    pos_file = Path(spaceranger_dir) / "spatial" / "tissue_positions.csv"
+    if not pos_file.exists():
+        pos_file = Path(spaceranger_dir) / "spatial" / "tissue_positions_list.csv"
+        df_pos = pd.read_csv(pos_file, sep=",", header=None, names=["barcode", "in_tissue", "x", "y", "pixel_row", "pixel_col"])
+    else:
+        df_pos = pd.read_csv(pos_file, sep=",", header=0, names=["barcode", "in_tissue", "x", "y", "pixel_row", "pixel_col"])
+    df_pos = df_pos[df_pos.in_tissue == True]
+        
+    # subsample cells randomly uniformly from each sample
+    np.random.seed(random_seed)
+    df_sampled = df_pos.sample(n=n_cells, replace=False)
+    df_sampled.sort_index(inplace=True)
+
+    # write a new h5ad file with the subsampled cells and the corresponding tissue_positions.csv file
+    if Path(f'{spaceranger_dir}/filtered_feature_bc_matrix.h5').exists():
+        adata = sc.read_10x_h5(f'{spaceranger_dir}/filtered_feature_bc_matrix.h5', gex_only=False)
+    else:
+        adata = sc.read_h5ad(f'{spaceranger_dir}/filtered_feature_bc_matrix.h5ad')
+    adata = adata[df_sampled.barcode.values, :]
+    # write the subsampled h5ad file
+    # mkdir
+    outputdir = Path(outputdir)
+    outputdir.mkdir(parents=True, exist_ok=True)
+    adata.write(outputdir / "filtered_feature_bc_matrix.h5ad")
+    # write the subsampled tissue_positions.csv file
+    outputdir2 = outputdir / 'spatial'
+    outputdir2.mkdir(parents=True, exist_ok=True)
+    df_sampled.to_csv(outputdir2 / "tissue_positions.csv", sep=",", index=False, header=True)
+
+    return df_sampled
+
+
+def subsample_snps(snp_dir, output_snp_dir, df_sampled, n_snps, random_seed=0):
+    """
+    Sub-sample SNPs from a list of spaceranger output directories.
+
+    Parameters
+    ----------
+    snp_dir : str
+        Path to the directory containing the SNP files.
+
+    output_snp_dir : str
+        Directory to save the subsampled SNP files.
+
+    df_sampled : pd.DataFrame
+        Dataframe containing the subsampled barcodes.
+    """
+    snp_dir = Path(snp_dir)
+    cell_snp_Aallele = scipy.sparse.load_npz(snp_dir / "cell_snp_Aallele.npz")
+    cell_snp_Ballele = scipy.sparse.load_npz(snp_dir / "cell_snp_Ballele.npz")
+    barcodes = np.loadtxt(snp_dir / "barcodes.txt", dtype=str)
+    unique_snp_ids = np.load(snp_dir / "unique_snp_ids.npy", allow_pickle=True)
+
+    # first get the indices of the barcodes to keep. The order of barcodes in df_sampled should be retained
+    map_barcodes_index = {x:i for i, x in enumerate(barcodes)}
+    idx = np.array([map_barcodes_index[x] for x in df_sampled.barcode.values if x in map_barcodes_index])
+    cell_snp_Aallele = cell_snp_Aallele[idx, :]
+    cell_snp_Ballele = cell_snp_Ballele[idx, :]
+    barcodes = barcodes[idx]
+
+    # subsample SNPs
+    np.random.seed(random_seed)
+    idx = np.random.choice(cell_snp_Aallele.shape[1], n_snps, replace=False)
+    idx = np.sort(idx)
+    cell_snp_Aallele = cell_snp_Aallele[:, idx]
+    cell_snp_Ballele = cell_snp_Ballele[:, idx]
+    unique_snp_ids = unique_snp_ids[idx]
+
+    # write the subsampled SNP files
+    output_snp_dir = Path(output_snp_dir)
+    output_snp_dir.mkdir(parents=True, exist_ok=True)
+    scipy.sparse.save_npz(output_snp_dir / "cell_snp_Aallele.npz", cell_snp_Aallele)
+    scipy.sparse.save_npz(output_snp_dir / "cell_snp_Ballele.npz", cell_snp_Ballele)
+    np.savetxt(output_snp_dir / "barcodes.txt", barcodes, fmt='%s')
+    np.save(output_snp_dir / "unique_snp_ids.npy", unique_snp_ids)
+
+    return
+
+
+def main(args):
+    # subsample cells: call either subsample_cells_multi or subsample_cells_single based on whether the input_filelist or spaceranger_dir is provided
+    if args.input_filelist is not None:
+        df_sampled = subsample_cells_multi(args.input_filelist, args.output_gex_dir, args.n_cells)
+    else:
+        df_sampled = subsample_cells_single(args.spaceranger_dir, args.output_gex_dir, args.n_cells)
+    
+    # subsample SNPs
+    subsample_snps(args.snp_dir, args.output_snp_dir, df_sampled, args.n_snps)
+
+    return
+    
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description='Subsample cells and SNPs from a list of spaceranger output directories.')
+
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument('--input_filelist', type=str, help='Path to a file containing a list of spaceranger output directories. Columns: bam, sample_id, spaceranger_dir')
+    group.add_argument('--spaceranger_dir', type=str, help='Path to the spaceranger output directory.')
+
+    parser.add_argument('--snp_dir', type=str, help='Path to the directory containing the SNP files.')
+    parser.add_argument('--output_gex_dir', type=str, help='Directory to save the subsampled h5ad files.')
+    parser.add_argument('--output_snp_dir', type=str, help='Directory to save the subsampled SNP files.')
+    parser.add_argument('--n_cells', type=int, help='Number of cells to subsample.')
+    parser.add_argument('--n_snps', type=int, help='Number of SNPs to subsample.')
+
+    args = parser.parse_args()
+
+    main(args)


### PR DESCRIPTION
* In case spaceranger outputs contain unzipped barcodes.tsv instead of barcodes.tsv.gz, add a check in `calicos.smk` to handle both cases.
* In case the cellsnp-lite and eagle2 outputs contain a large number of SNPs and spots/cells that can't be loaded in a dense matrix, the `utils/get_snp_matrix.py` code in the preprocessing step is updated to combine eagle2 phasing into cellsnp-lite genotyping using all sparse matrix operations, which eventually outputs eagle2-phased A allele count and B allele count sparse matrices.